### PR TITLE
fix condition of combining edge points

### DIFF
--- a/src/grid/composite.jl
+++ b/src/grid/composite.jl
@@ -242,6 +242,10 @@ function LogDensedGrid(type, bound, dense_at, N, minterval, order, T=Float64; is
     @assert bound[1] <= dense_at[1] <= dense_at[end] <= bound[2]
 
     dp = Vector{T}([])
+    # construct panel points
+    # combine two panel points when they are closer than 2minterval
+    # this is to ensure 1. subgrids are constructed on a interval that is not too small
+    # and 2. the minimal interval is taken around both points
     for i in 1:length(dense_at)
         if i == 1
             if abs(dense_at[i] - bound[1]) <= 2minterval

--- a/src/grid/composite.jl
+++ b/src/grid/composite.jl
@@ -244,15 +244,15 @@ function LogDensedGrid(type, bound, dense_at, N, minterval, order, T=Float64; is
     dp = Vector{T}([])
     for i in 1:length(dense_at)
         if i == 1
-            if abs(dense_at[i] - bound[1]) < minterval
+            if abs(dense_at[i] - bound[1]) <= 2minterval
                 push!(dp, bound[1])
-            elseif abs(dense_at[i] - bound[2]) < minterval
+            elseif abs(dense_at[i] - bound[2]) <= 2minterval
                 push!(dp, bound[2])
             else
                 push!(dp, dense_at[i])
             end
         elseif i != length(dense_at)
-            if abs(dense_at[i] - dp[end]) < minterval
+            if abs(dense_at[i] - dp[end]) <= 2minterval
                 if dp[end] != bound[1]
                     dp[end] = (dense_at[i] + dense_at[i-1]) / 2.0
                 end
@@ -260,13 +260,13 @@ function LogDensedGrid(type, bound, dense_at, N, minterval, order, T=Float64; is
                 push!(dp, dense_at[i])
             end
         else
-            if abs(dense_at[i] - bound[2]) < minterval
-                if abs(dp[end] - bound[2]) < minterval
+            if abs(dense_at[i] - bound[2]) <= 2minterval
+                if abs(dp[end] - bound[2]) <= 2minterval
                     dp[end] = bound[2]
                 else
                     push!(dp, bound[2])
                 end
-            elseif abs(dense_at[i] - dp[end]) < minterval
+            elseif abs(dense_at[i] - dp[end]) <= 2minterval
                 if dp[end] != bound[1]
                     dp[end] = (dense_at[i] + dense_at[i-1]) / 2.0
                 end

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -235,6 +235,13 @@ end
         # println(comp.grid)
         comp = CompositeGrid.LogDensedGrid(:uniform, [0.0, 10.0], [0.5, 10.0], 4, 0.001, 4)
         # println(comp.grid)
+
+        # test edge case when two panel points are exactly minterval away
+        # raw panel will be [0.0, 5.0,5.001,5.002,10.0], 
+        # after construction it will be [0.0, 5.001, 10.0]
+        comp = CompositeGrid.LogDensedGrid(:uniform, [0.0, 10.0], [5.0, 5.002], 4, 0.001, 4)
+        @test length(comp.panel) == 3
+        @test isapprox(comp.panel[2], 5.001, atol=0.001)
     end
 
 end


### PR DESCRIPTION
Fixed a bug that causes error when constructing log densed grids.
Old constructor of LDG combine two panel points only when p[2]-p[1]<minterval, and this leads to construction of Log grids with bound[2]-bound[1]==minterval, which will be rejected by the recently updated assertion 0<minterval<bound[2]-bound[1].
The condition is adjusted to p[2]-p[1]<=2minterval, which still guarantees minimal interval is smaller than minterval, while eliminates cases with too small interval.